### PR TITLE
fix(security): pin etils-actions/pypi-auto-publish and other Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     # Checkout the latest version of the repo and set up Python.
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.x"
     # Install build dependencies, build from source and store the distribution packages.
@@ -106,7 +106,7 @@ jobs:
 
   #   steps:
   #   # Publish the package (if local `__version__` > pip version)
-  #   - uses: etils-actions/pypi-auto-publish@v1.5.2
+  #   - uses: etils-actions/pypi-auto-publish@485c06f78cf81532b987ea00bfbfd0e59ac6fdfe # v1.5.2
   #     with:
   #       pypi-token: ${{ secrets.PYPI_API_TOKEN }}
   #       parse-changelog: true

--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -13,10 +13,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Install deps
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.10"
         # Uncomment to cache of pip dependencies (if tests too slow)
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     # Publish the package (if local `__version__` > pip version)
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN }}
         gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This workflow uses **mutable tag references** for GitHub Actions including `etils-actions/pypi-auto-publish@v1` — a third-party action. If the tag is silently redirected, malicious code runs in the job holding `PYPI_API_TOKEN`, enabling a supply-chain attack on every downstream user.

## Fix

All action references pinned to immutable commit SHAs. Follows the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).